### PR TITLE
Correct `tiller_namespace` schema

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,8 @@ func main() {
 					},
 					"tiller_namespace": {
 						Type:     schema.TypeString,
-						Required: false,
+						Optional: true,
+						Default:  "",
 						Description: "The namespace tiller is running in." +
 							"If tiller is installed into another namespace" +
 							"by default tiller is in kube-system but can be installed" +


### PR DESCRIPTION
This fixes a bug in https://github.com/djhaskin987/terraform-provider-helmcmd/pull/2.

`terraform apply` always failed:
```
  Error: provider.helmcmd: Internal validation of the provider failed! This is always a bug
  with the provider itself, and not a user issue. Please report
  this bug:

  1 error(s) occurred:

  * tiller_namespace: One of optional, required, or computed must be set
```

(Consider adding a PR template that requires some validation of the change?)

# Verification
`terraform apply` now works -- created and updated a chart in my EKS cluster, and verified deployment.
